### PR TITLE
fix iterator target next access

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -52,10 +52,14 @@ const getKeyStringShadowed = (key, isShadowed) => {
 }
 
 const isIterator = (target) => {
-    return (
-        Reflect.has(target, 'next') &&
-        typeof Object.getOwnPropertyDescriptor(target, 'next')?.get === 'function'
-    );
+    let result = false;
+    if (Reflect.has(target, 'next')) {
+        const desc = Object.getOwnPropertyDescriptor(target, 'next');
+        result =
+            typeof desc?.get === 'function' ||
+            typeof desc?.value === 'function';
+    }
+    return result;
 }
 
 // We include Map and Set in addition to iterables/iterators for better key display

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ const getKeyStringShadowed = (key, isShadowed) => {
 const isIterator = (target) => {
     return (
         Reflect.has(target, 'next') &&
-        typeof target.next === 'function'
+        typeof Object.getOwnPropertyDescriptor(target, 'next')?.get === 'function'
     );
 }
 


### PR DESCRIPTION
2ae8f1b2c696a5458c81e7653e55a217288dfb14 introduced doesn't handle iterator next access correctly:

![Screenshot 2023-12-12 at 18 13 45](https://github.com/LavaMoat/LavaTube/assets/13243797/19a045a7-32ca-46b3-b7ab-48a15e41614d)

this PR attempts to fix this (currently breaks tests)

EDIT: tests breaking is addressed @ 19155b9