### PR TITLE
fix cross origin window

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,13 @@ function getAllFrames(arr, win){
 
 const frames = getAllFrames([], globalThis?.top || globalThis);
 
-const isAnotherWindowProxy = (obj) => {
-    return frames.includes(obj) && obj !== globalThis;
+const isCrossOriginWindowProxy = (obj) => {
+    return (
+        // is actually a window proxy object?
+        frames.includes(obj) &&
+        // is cross-origin?
+        Object.getPrototypeOf.call(globalThis, obj) === null
+    );
 }
 
 const isPrimitive = (obj) => {
@@ -131,7 +136,7 @@ const getIterableValues = (target, realms) => {
 
 const getAllProps = (target, shouldInvokeGetters, getAdditionalProps, realms) => {
     const props = [];
-    if (isAnotherWindowProxy(target)) {
+    if (isCrossOriginWindowProxy(target)) {
         return props;
     }
     const proto = Reflect.getPrototypeOf(target);

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,17 @@
+function getAllFrames(arr, win){
+    for (let i = 0; i < win.length || 0; i++) {
+        getAllFrames(arr, win[i]);
+    }
+    arr.push(win);
+    return arr;
+}
+
+const frames = getAllFrames([], globalThis?.top || globalThis);
+
+const isAnotherWindowProxy = (obj) => {
+    return frames.includes(obj) && obj !== globalThis;
+}
+
 const isPrimitive = (obj) => {
     return !Object.is(obj, Object(obj));
 }
@@ -117,6 +131,9 @@ const getIterableValues = (target, realms) => {
 
 const getAllProps = (target, shouldInvokeGetters, getAdditionalProps, realms) => {
     const props = [];
+    if (isAnotherWindowProxy(target)) {
+        return props;
+    }
     const proto = Reflect.getPrototypeOf(target);
     if (proto) {
         props.push(['<prototype>', proto]);


### PR DESCRIPTION
in browser env, walker finds its way to WindowProxy objects of other realms, and when those are cross origin if crashes - this PR detects those before and avoids the crash